### PR TITLE
Mention "Accessibilité : non conforme"

### DIFF
--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -190,6 +190,7 @@ viewFooter session =
                 , a [ Route.href Route.Convention ] [ text "Charte de bonne conduite" ]
                 , a [ Route.href Route.PrivacyPolicy ] [ text "Politique de confidentialité" ]
                 ]
+            , div [] [ text "Accessibilité : non conforme" ]
             , span [] [ text <| "Version : " ++ session.version ]
             ]
         ]


### PR DESCRIPTION
*TLDR : cette mention est obligatoire pour les sites du service public.*

Hello !
Cette PR vise à corriger une des obligations légales qu'ont tous les services numériques publics : **afficher le niveau de conformité du site sur toutes les pages.** 

![image](https://user-images.githubusercontent.com/1374389/111307493-d2b1a180-8659-11eb-8088-b31d46ae2a89.png)

À propos de cette mention : on considère qu'un site est "non conforme" en terme d'accessibilité tant que le niveau de conformité au RGAA (Référentiel général d'accessibilité pour les administrations) est inconnu. Pour pouvoir afficher "partiellement conforme" ou "totalement conforme", il est nécessaire d'effectuer un audit auprès d'un cabinet d'expert qui mesurera le taux de conformité.

Une 2ème obligation légale est de **mettre en ligne une déclaration d'accessibilité**. (Je ne fais pas la PR car c'est plus compliqué techniquement pour moi designer 🙈). Voici quelques exemples : 
- [La page Accessibilité de signal.conso.gouv.fr](https://signal.conso.gouv.fr/accessibilite) qui affiche le score de l'audit
- [La page Accessibilité du site des Designers Transverses](https://design.incubateur.net/accessibility) qui indique que le site n'a pas encore été audité, mais rassure les utilisateurs concernés sur les mesures qui ont été prises.
- [Le générateur de déclaration d'accessibilité](https://betagouv.github.io/a11y-generateur-declaration/#create) pour obtenir un exemple de déclaration conforme en quelques clics.

Plus d'infos sur le [Kit Accessibilité](https://doc.incubateur.net/design/ressources-design/kit-accessibilite) de la documentation design ou sur #domaine-accessibilité sur le Slack.